### PR TITLE
generate_parameters now can go smaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Building on MacOS is not reccomended as CUDA support is harder to use. (Apple mo
 ./generate_parameters
 ```
 
+When iterating on your implementation for correctness (and not performance)
+smaller constraint systems are fine. In that case, `./generate_parameters fast`
+will give you smaller parameters that don't take as long to generate or
+prove with.
+
 ### Run
 ``` bash
 ./main MNT4753 compute MNT4753-parameters MNT4753-input MNT4753-output

--- a/libsnark/generate_parameters.cpp
+++ b/libsnark/generate_parameters.cpp
@@ -124,6 +124,14 @@ int generate_paramaters(
 
 int main(int argc, const char * argv[])
 {
-  generate_paramaters<mnt4753_pp>(20, "MNT4753-parameters", "MNT4753-input");
-  generate_paramaters<mnt6753_pp>(15, "MNT6753-parameters", "MNT6753-input");
+  int log2_d_4753 = 20, log2_d_6753 = 15;
+  if (argc > 1) {
+    std::string fastflag(argv[1]);
+    if (fastflag == "fast") {
+      log2_d_4753 = 14;
+      log2_d_6753 = 10;
+    }
+  }
+  generate_paramaters<mnt4753_pp>(log2_d_4753, "MNT4753-parameters", "MNT4753-input");
+  generate_paramaters<mnt6753_pp>(log2_d_6753, "MNT6753-parameters", "MNT6753-input");
 }


### PR DESCRIPTION
When iterating on correctness, the more realistic constraint system is annoyingly slow.