### PR TITLE
parse the 'CPU' argument

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     build:
         resource_class: large
         docker:
-            - image: ubuntu:xenial
+            - image: ubuntu:bionic
         steps:
             - checkout
             - run: apt-get update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
             - image: ubuntu:xenial
         steps:
             - checkout
+            - run: apt-get update
             - run: apt-get install -y build-essential cmake git libomp-dev libgmp3-dev libprocps-dev python-markdown libboost-all-dev libssl-dev pkg-config
             - run: ./build.sh
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     build:
         resource_class: large
         docker:
-            - image: ubuntu/xenial
+            - image: ubuntu:xenial
         steps:
             - checkout
             - run: apt-get install -y build-essential cmake git libomp-dev libgmp3-dev libprocps-dev python-markdown libboost-all-dev libssl-dev pkg-config

--- a/libsnark/main.cpp
+++ b/libsnark/main.cpp
@@ -237,18 +237,23 @@ int main(int argc, const char * argv[])
   setbuf(stdout, NULL);
   std::string curve(argv[1]);
   std::string mode(argv[2]);
+  std::string device(argv[3]);
 
-  const char* params_path = argv[3];
-  const char* input_path = argv[4];
-  const char* output_path = argv[5];
+  const char* params_path = argv[4];
+  const char* input_path = argv[5];
+  const char* output_path = argv[6];
 
-  if (curve == "MNT4753") {
-    if (mode == "compute") {
-      return run_prover<mnt4753_pp>(params_path, input_path, output_path);
-    }
-  } else if (curve == "MNT6753") {
-    if (mode == "compute") {
-      return run_prover<mnt6753_pp>(params_path, input_path, output_path);
+  if (device != "CPU") {
+    fprintf(stderr, "non-CPU code isn't part of this reference!");
+  } else {
+    if (curve == "MNT4753") {
+      if (mode == "compute") {
+        return run_prover<mnt4753_pp>(params_path, input_path, output_path);
+      }
+    } else if (curve == "MNT6753") {
+      if (mode == "compute") {
+        return run_prover<mnt6753_pp>(params_path, input_path, output_path);
+      }
     }
   }
 }


### PR DESCRIPTION
While the CUDA changes were easy to back out, they extended the CLI parameters slightly. This makes the reference work with the instructions on coinlist.