### PR TITLE
Doc/build updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
             - checkout
             - run: apt-get update
             - run: apt-get install -y build-essential cmake git libomp-dev libgmp3-dev libprocps-dev python-markdown libboost-all-dev libssl-dev pkg-config
-            - run: ./build.sh
+            - run: env "EXTRA_CMAKE_ARGS_FOR_CI=-DCUDA_ARCH_LIST=Volta" ./build.sh
 workflows:
     version: 2
     main_workflow:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,13 @@ This directory contains a reference CPU implementation of  the
 Groth16 prover
 using [libsnark](README-libsnark.md).
 
-#### Dependancies
+There are two provers implemented in this repository. The first is `libsnark/main.cpp`, which has _the_ CPU libsnark reference prover that we compare benchmarks against. You can modify this with debug info if you need, but you shouldn't try and add CUDA calls in it.
 
-The code should compile and run on Ubuntu 18.04 with the following dependancies installed:
+The other prover is in `cuda_prover_piecewise.cu`. It also calls the CPU-based libsnark functions, although through a wrapper library to avoid having to include the libsnark headers‡. Once you have GPU implementations of the expensive algorithms (FFT, multiexp), replace the calls to methods in `B` with calls to your GPU functions. You will probably need to add functions to the wrapper classes (implemented in `libsnark/prover_reference_functions.cpp` and `libsnark/prover_reference_include/prover_reference_functions.hpp`) to copy libsnark data into the format you need for CUDA. If you need help dealing with the wrapper functions, ask around in the `#snark-challenge` discord channel.
+
+#### Dependencies
+
+The code should compile and run on Ubuntu 18.04 with the following dependencies installed:
 
 ``` bash
 sudo apt-get install -y build-essential \
@@ -17,11 +21,12 @@ sudo apt-get install -y build-essential \
     python-markdown \
     libboost-all-dev \
     libssl-dev \
-    pkg-config
+    pkg-config \
+    nvidia-cuda-toolkit
 ```
 
 
-Building on MacOS is not reccomended as CUDA support is harder to use. (Apple mostly ships with AMD.)
+Building on MacOS is not recommended as CUDA support is harder to use. (Apple mostly ships with AMD.)
 
 
 #### Build
@@ -43,9 +48,13 @@ prove with.
 ``` bash
 ./main MNT4753 compute MNT4753-parameters MNT4753-input MNT4753-output
 ./main MNT6753 compute MNT6753-parameters MNT6753-input MNT6753-output
+./cuda_prover_piecewise MNT4753 compute MNT4753-parameters MNT4753-input MNT4753-output_cuda
+./cuda_prover_piecewise MNT6753 compute MNT6753-parameters MNT6753-input MNT6753-output_cuda
 ```
 
 ### Check results
 ``` bash
-sha256sum MNT4753-output MNT6753-output
+sha256sum MNT4753-output MNT6753-output MNT4753-output_cuda MNT6753-output_cuda
 ```
+
+‡ Due to some bug with `nvcc` in version `10.1`, including any of the `mnt4`/`mnt6` `libff` headers (a library libsnark uses for finite field arithmetic) leads to a compilation failure. The wrapper library uses something like the [pImpl idiom](https://en.cppreference.com/w/cpp/language/pimpl) to hide the need for those headers from the caller.

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 mkdir build
 pushd build
-  cmake -DMULTICORE=ON -DUSE_PT_COMPRESSION=OFF .. 
+  cmake -DMULTICORE=ON -DUSE_PT_COMPRESSION=OFF $EXTRA_CMAKE_ARGS_FOR_CI ..
   make -j12 main generate_parameters cuda_prover_piecewise
 popd
 mv build/libsnark/main .

--- a/cuda-fixnum/CMakeLists.txt
+++ b/cuda-fixnum/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CUDA_ARCH_LIST Auto CACHE LIST
      compute capability versions (6.1, 7.0, etc) to generate code for. \
      Set to Auto for automatic detection (default)."
 )
-cuda_select_nvcc_arch_flags(CUDA_ARCH_FLAGS Volta)
+cuda_select_nvcc_arch_flags(CUDA_ARCH_FLAGS ${CUDA_ARCH_LIST})
 string(REPLACE ";" " " CUDA_ARCH_FLAGS_SPACES "${CUDA_ARCH_FLAGS}")
 
 string(APPEND CMAKE_CUDA_FLAGS " ${CUDA_ARCH_FLAGS_SPACES}")

--- a/cuda_prover_piecewise.cu
+++ b/cuda_prover_piecewise.cu
@@ -11,9 +11,6 @@
 #include <modnum/modnum_monty_cios.cu>
 #include <modnum/modnum_monty_redc.cu>
 
-// cuda-fixnum/main.cu has some example code. this declaration lets us run it.
-int do_fixnum_example(const char *inputs_file, const char *outputs_file);
-
 // This is where all the FFTs happen
 
 // template over the bundle of types and functions.
@@ -104,23 +101,19 @@ int main(int argc, char **argv) {
   setbuf(stdout, NULL);
   std::string curve(argv[1]);
   std::string mode(argv[2]);
-  std::string device(argv[3]); // this "device" arg
 
-  const char *params_path = argv[4];
-  const char *input_path = argv[5];
-  const char *output_path = argv[6];
-  if (device == "CPU") {
-    if (curve == "MNT4753") {
-      if (mode == "compute") {
-        run_prover<mnt4753_libsnark>(params_path, input_path, output_path);
-      }
-    } else if (curve == "MNT6753") {
-      if (mode == "compute") {
-        run_prover<mnt6753_libsnark>(params_path, input_path, output_path);
-      }
+  const char *params_path = argv[3];
+  const char *input_path = argv[4];
+  const char *output_path = argv[5];
+
+  if (curve == "MNT4753") {
+    if (mode == "compute") {
+      run_prover<mnt4753_libsnark>(params_path, input_path, output_path);
     }
-  } else if (device == "GPU") {
-    do_fixnum_example(argv[4], argv[5]);
+  } else if (curve == "MNT6753") {
+    if (mode == "compute") {
+      run_prover<mnt6753_libsnark>(params_path, input_path, output_path);
+    }
   }
 
   return 0;

--- a/libsnark/main.cpp
+++ b/libsnark/main.cpp
@@ -237,23 +237,18 @@ int main(int argc, const char * argv[])
   setbuf(stdout, NULL);
   std::string curve(argv[1]);
   std::string mode(argv[2]);
-  std::string device(argv[3]);
 
-  const char* params_path = argv[4];
-  const char* input_path = argv[5];
-  const char* output_path = argv[6];
+  const char* params_path = argv[3];
+  const char* input_path = argv[4];
+  const char* output_path = argv[5];
 
-  if (device != "CPU") {
-    fprintf(stderr, "non-CPU code isn't part of this reference!");
-  } else {
-    if (curve == "MNT4753") {
-      if (mode == "compute") {
-        return run_prover<mnt4753_pp>(params_path, input_path, output_path);
-      }
-    } else if (curve == "MNT6753") {
-      if (mode == "compute") {
-        return run_prover<mnt6753_pp>(params_path, input_path, output_path);
-      }
+  if (curve == "MNT4753") {
+    if (mode == "compute") {
+      return run_prover<mnt4753_pp>(params_path, input_path, output_path);
+    }
+  } else if (curve == "MNT6753") {
+    if (mode == "compute") {
+      return run_prover<mnt6753_pp>(params_path, input_path, output_path);
     }
   }
 }


### PR DESCRIPTION
Puts the GPU autodetection back (and work around it on CI), remove the old `device` argument that was misleading, and add some notes to the README.